### PR TITLE
Add missing function to list-all script

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -32,4 +32,11 @@ get_download_url() {
   echo "https://api.github.com/repos/$repository/tags"
 }
 
+build_header() {
+  local key=${1}
+  local val=${2}
+
+  echo "'$key: $val'"
+}
+
 list_all


### PR DESCRIPTION
# Description
Add `build_header` function since part of the `list-all` script was dependent on it, and the missing function was causing the script to fail.
