### PR TITLE
Fix requests with auth token headers

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -13,11 +13,10 @@ readonly repository="TheLocehiliosan/yadm"
 readonly toolname="yadm"
 
 # rate limit support with a proper token
-HEADERS=()
+CURL_CMD="curl -fsL"
 if [ -n "${OAUTH_TOKEN:-}" ]
 then
-  header=$(build_header Authorization "token ${OAUTH_TOKEN}")
-  HEADERS+=("$header")
+  CURL_CMD="$CURL_CMD -H 'Authorization: token ${OAUTH_TOKEN}'"
 fi
 
 download() {
@@ -25,7 +24,7 @@ download() {
   local -r download_url="$(get_download_url "$filename")"
 
   echo "Downloading ${toolname} version ${ASDF_INSTALL_VERSION} from ${download_url}"
-  if curl "${HEADERS[@]/#/-H }" -fsL "${download_url}" -o "${ASDF_DOWNLOAD_PATH}/${filename}"
+  if $CURL_CMD "${download_url}" -o "${ASDF_DOWNLOAD_PATH}/${filename}"
   then
     echo "Successfully downloaded ${filename}"
     exit 0
@@ -40,13 +39,6 @@ get_download_url() {
   local -r filename=$1
 
   echo "https://github.com/$repository/archive/refs/tags/$filename"
-}
-
-build_header() {
-  local key=${1}
-  local val=${2}
-
-  echo "'$key: $val'"
 }
 
 download

--- a/bin/list-all
+++ b/bin/list-all
@@ -8,17 +8,16 @@ set \
 readonly repository="TheLocehiliosan/yadm"
 
 # rate limit support with a proper token
-HEADERS=()
+CURL_CMD="curl -fsL"
 if [ -n "${OAUTH_TOKEN:-}" ]
 then
-  header=$(build_header Authorization "token ${OAUTH_TOKEN}")
-  HEADERS+=("$header")
+  CURL_CMD="$CURL_CMD -H 'Authorization: token ${OAUTH_TOKEN}'"
 fi
 
 list_all() {
   local -r download_url="$(get_download_url)"
 
-  versions=$(curl "${HEADERS[@]/#/-H }" -fsL "${download_url}" | grep '\bname\b' | sed 's/"name": //g;s/"//g;s/,//g')
+  versions=$($CURL_CMD "${download_url}" | grep '\bname\b' | sed 's/"name": //g;s/"//g;s/,//g')
   echo "$versions" | sort_versions | xargs
 }
 
@@ -30,13 +29,6 @@ sort_versions() {
 # return the full URL to the download
 get_download_url() {
   echo "https://api.github.com/repos/$repository/tags"
-}
-
-build_header() {
-  local key=${1}
-  local val=${2}
-
-  echo "'$key: $val'"
 }
 
 list_all


### PR DESCRIPTION
# Description
Remove the `build_header` function, as it's no longer needed for a
single header definition. Instead, define the headers inline.

Fixes #1
